### PR TITLE
Check whether "path" is set in $storeParsedUrl in module-store/Model/Store

### DIFF
--- a/app/code/Magento/Store/Model/Store.php
+++ b/app/code/Magento/Store/Model/Store.php
@@ -1249,7 +1249,7 @@ class Store extends AbstractExtensibleModel implements
             . '://'
             . $storeParsedUrl['host']
             . (isset($storeParsedUrl['port']) ? ':' . $storeParsedUrl['port'] : '')
-            . $storeParsedUrl['path']
+            . (isset($storeParsedUrl['path']) ? ':' . $storeParsedUrl['path'] : '')
             . $requestStringPath
             . ($currentUrlQueryParams ? '?' . http_build_query($currentUrlQueryParams) : '');
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

This pull request adds a check in the getCurrentUrl function in module-store/Model/Store for whether "path" is defined in the $storeParsedUrl array. While the scheme and and host can be reliably expected to be set, the same cannot be said for the "path", if the store URL is "https://example.com", which can lead to an error of "path" not being set.

### Related Pull Requests
<!-- related pull request placeholder -->

None.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

None, as far as I know

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

Just using the getCurrentUrl function should work as a test case. Preferably, the storeUrl should be without a trailing slash, like "https://example.com"

### Contribution checklist (*)
 - [✅] Pull request has a meaningful description of its purpose
 - [✅] All commits are accompanied by meaningful commit messages
 - [✅] All new or changed code is covered with unit/integration tests (if applicable)
 - [✅] All automated tests passed successfully (all builds are green)
